### PR TITLE
added nolimit flag to bypass rate limiting

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -13,6 +13,7 @@ import (
 
 type myTransport struct {
 	matcher
+	limiters
 	stats   map[string]MonitoringPath
 	statsMu sync.RWMutex
 }
@@ -94,7 +95,7 @@ func (t *myTransport) RoundTrip(request *http.Request) (*http.Response, error) {
 	parsedRequests := parseRequests(request)
 
 	for _, parsedRequest := range parsedRequests {
-		if !AllowLimit(parsedRequest) {
+		if !t.AllowLimit(parsedRequest) {
 			log.Println("User hit the limit:", parsedRequest.Path, " from IP: ", parsedRequest.RemoteAddr)
 			return &http.Response{
 				Body:       ioutil.NopCloser(bytes.NewBufferString("You hit the request limit")),

--- a/limits.go
+++ b/limits.go
@@ -9,34 +9,44 @@ import (
 	"golang.org/x/time/rate"
 )
 
-var visitors = make(map[string]*rate.Limiter)
-var mtx sync.Mutex
+type limiters struct {
+	noLimitIPs map[string]struct{} // concurrent read safe after init.
+	visitors   map[string]*rate.Limiter
+	sync.RWMutex
+}
 
 func per(eventCount int, duration time.Duration) rate.Limit {
 	return rate.Every(duration / time.Duration(eventCount))
 }
 
-func addVisitor(ip string) *rate.Limiter {
-	limiter := rate.NewLimiter(per(requestsPerMinuteLimit, time.Minute), 10)
+func (ls *limiters) tryAddVisitor(ip string) *rate.Limiter {
+	ls.Lock()
+	defer ls.Unlock()
+	limiter, exists := ls.visitors[ip]
+	if exists {
+		return limiter
+	}
+	limiter = rate.NewLimiter(per(requestsPerMinuteLimit, time.Minute), 10)
 	log.Println("Added new visitor:", ip, " limit ", fmt.Sprint(requestsPerMinuteLimit))
-	mtx.Lock()
-	visitors[ip] = limiter
-	mtx.Unlock()
+	ls.visitors[ip] = limiter
 	return limiter
 }
 
-func getVisitor(ip string) *rate.Limiter {
-	mtx.Lock()
-	limiter, exists := visitors[ip]
-	mtx.Unlock()
+func (ls *limiters) getVisitor(ip string) *rate.Limiter {
+	ls.RLock()
+	limiter, exists := ls.visitors[ip]
+	ls.RUnlock()
 	if !exists {
-		return addVisitor(ip)
+		return ls.tryAddVisitor(ip)
 	}
 	return limiter
 }
 
-func AllowLimit(r ModifiedRequest) bool {
-	limiter := getVisitor(r.RemoteAddr)
+func (ls *limiters) AllowLimit(r ModifiedRequest) bool {
+	if _, ok := ls.noLimitIPs[r.RemoteAddr]; ok {
+		return true
+	}
+	limiter := ls.getVisitor(r.RemoteAddr)
 	if limiter.Allow() == false {
 		log.Println("Exceeds limiter's burst path: ", r.Path, " ip: ", r.RemoteAddr)
 		return false


### PR DESCRIPTION
This PR adds a new flag, `-nolimit` which accepts a csv of ips to exclude from rate limiting. This will allow the load testers to run unrestricted.
Fixes #9 