### PR TITLE
Use HTTP status codes in combo with JSON-RPC errors #15

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -92,7 +92,7 @@ func parseRequests(r *http.Request) []ModifiedRequest {
 	return res
 }
 
-func jsonRPCError(id json.RawMessage, code int, msg string) (*http.Response, error) {
+func jsonRPCError(id json.RawMessage, jsonCode, httpCode int, msg string) (*http.Response, error) {
 	type errResponse struct {
 		Version string          `json:"jsonrpc"`
 		ID      json.RawMessage `json:"id"`
@@ -105,7 +105,7 @@ func jsonRPCError(id json.RawMessage, code int, msg string) (*http.Response, err
 		Version: "2.0",
 		ID:      id,
 	}
-	resp.Error.Code = code
+	resp.Error.Code = jsonCode
 	resp.Error.Message = msg
 	body, err := json.Marshal(&resp)
 	if err != nil {
@@ -113,7 +113,7 @@ func jsonRPCError(id json.RawMessage, code int, msg string) (*http.Response, err
 	}
 	return &http.Response{
 		Body:       ioutil.NopCloser(bytes.NewReader(body)),
-		StatusCode: http.StatusOK,
+		StatusCode: httpCode,
 	}, nil
 }
 
@@ -126,19 +126,19 @@ func (t *myTransport) RoundTrip(request *http.Request) (*http.Response, error) {
 	for _, parsedRequest := range parsedRequests {
 		if !t.AllowLimit(parsedRequest) {
 			log.Println("User hit the limit:", parsedRequest.Path, " from IP: ", parsedRequest.RemoteAddr)
-			return jsonRPCError(parsedRequest.ID, -32000, "You hit the request limit")
+			return jsonRPCError(parsedRequest.ID, -32000, http.StatusTooManyRequests, "You hit the request limit")
 		}
 
 		if !t.MatchAnyRule(parsedRequest) {
 			log.Println("Not allowed:", parsedRequest.Path, " from IP: ", parsedRequest.RemoteAddr)
-			return jsonRPCError(parsedRequest.ID, -32601, "You are not authorized to make this request")
+			return jsonRPCError(parsedRequest.ID, -32601, http.StatusUnauthorized, "You are not authorized to make this request")
 		}
 	}
 	request.Host = request.RemoteAddr //workaround for CloudFlare
 	response, err = http.DefaultTransport.RoundTrip(request)
 	if err != nil {
 		log.Println("Error response from RoundTrip:", err)
-		return jsonRPCError(parsedRequests[0].ID, -32603, "Internal error") //returning ID of the first request
+		return jsonRPCError(parsedRequests[0].ID, -32603, response.StatusCode, "Internal error") //returning ID of the first request
 	}
 
 	elapsed := time.Since(start)


### PR DESCRIPTION
In case of server error, it's just repeating response code from the server