### PR TITLE
remove redundant log line; only log every rate limit when verbose

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -129,7 +129,9 @@ func (t *myTransport) RoundTrip(request *http.Request) (*http.Response, error) {
 
 	for _, parsedRequest := range parsedRequests {
 		if !t.AllowLimit(parsedRequest) {
-			log.Println("User hit the limit:", parsedRequest.Path, " from IP: ", parsedRequest.RemoteAddr)
+			if verboseLogging {
+				log.Println("User hit the limit:", parsedRequest.Path, " from IP: ", parsedRequest.RemoteAddr)
+			}
 			return jsonRPCResponse(parsedRequest.ID, -32000, http.StatusTooManyRequests, "You hit the request limit")
 		}
 

--- a/limits.go
+++ b/limits.go
@@ -48,7 +48,6 @@ func (ls *limiters) AllowLimit(r ModifiedRequest) bool {
 	}
 	limiter := ls.getVisitor(r.RemoteAddr)
 	if limiter.Allow() == false {
-		log.Println("Exceeds limiter's burst path: ", r.Path, " ip: ", r.RemoteAddr)
 		return false
 	}
 	return true


### PR DESCRIPTION
Our logs show many 500k/s+ bursts of these log line pairs:
```
2018/06/16 05:21:31 Exceeds limiter's burst path:  eth_call  ip:  <ip>
2018/06/16 05:21:30 User hit the limit: eth_call  from IP:  <same ip>
```
This PR drops one and only does the other when verbose.