### PR TITLE
example request/response pairs under /x/{method}

### DIFF
--- a/main.go
+++ b/main.go
@@ -86,6 +86,7 @@ func main() {
 
 		r.Get("/", server.HomePage)
 		r.Get("/stats", server.Stats)
+		r.Get("/x/{method}", server.Example)
 		r.HandleFunc("/*", server.RPCProxy)
 		log.Fatal(http.ListenAndServe(":"+port, r))
 		return nil


### PR DESCRIPTION
This PR adds some example request/response pairs under `/x/{method}`, and links them from the homepage. These are live calls, so it's a quick way to check on the latest block/snapshot/whatever. Only the ones with simple default parameters work for now, but we can easily add others by pulling some parameters from the url.
![screenshot from 2019-01-09 12-58-29](https://user-images.githubusercontent.com/1194128/50921696-47e81300-140e-11e9-9684-6560051b63a0.png)

The latest clique snapshot shows latest block, current signers, and even the last signed block for each signer:
![screenshot from 2019-01-09 12-58-21](https://user-images.githubusercontent.com/1194128/50921705-4a4a6d00-140e-11e9-9b24-083ad35d644b.png)
Closes #23 